### PR TITLE
feat: add settings module with pydantic-settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+LINE_CHANNEL_SECRET=your-channel-secret
+LINE_CHANNEL_ACCESS_TOKEN=your-channel-access-token
+# STORAGE_DIR=~/.ai-journaling-agent/data
+# PORT=8000

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ __pycache__/
 dist/
 build/
 .venv/
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
 
 # outputs（jj管理外）
 outputs/
@@ -16,6 +19,7 @@ outputs/
 # Environment
 .env
 .env.*
+!.env.example
 
 # OS
 .DS_Store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "AI agent-based journaling app for cultivating mindfulness and wel
 requires-python = ">=3.12"
 dependencies = [
     "line-bot-sdk>=3.0",
+    "pydantic-settings>=2.0",
 ]
 
 [dependency-groups]

--- a/src/ai_journaling_agent/core/config.py
+++ b/src/ai_journaling_agent/core/config.py
@@ -1,0 +1,24 @@
+"""Application settings loaded from environment variables."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Application settings.
+
+    Required environment variables:
+        LINE_CHANNEL_SECRET
+        LINE_CHANNEL_ACCESS_TOKEN
+    """
+
+    model_config = SettingsConfigDict(env_file=".env")
+
+    line_channel_secret: str
+    line_channel_access_token: str
+    storage_dir: Path = Field(default=Path.home() / ".ai-journaling-agent" / "data")
+    port: int = 8000

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,61 @@
+"""Tests for Settings configuration module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from ai_journaling_agent.core.config import Settings
+
+
+class TestSettingsRequired:
+    """Required fields must be provided."""
+
+    def test_missing_channel_secret_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("LINE_CHANNEL_SECRET", raising=False)
+        monkeypatch.delenv("LINE_CHANNEL_ACCESS_TOKEN", raising=False)
+        with pytest.raises(ValidationError):
+            Settings()  # type: ignore[call-arg]
+
+    def test_valid_credentials(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LINE_CHANNEL_SECRET", "test-secret")
+        monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "test-token")
+        settings = Settings()  # type: ignore[call-arg]
+        assert settings.line_channel_secret == "test-secret"
+        assert settings.line_channel_access_token == "test-token"
+
+
+class TestSettingsDefaults:
+    """Default values are applied correctly."""
+
+    def test_default_port(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LINE_CHANNEL_SECRET", "s")
+        monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "t")
+        settings = Settings()  # type: ignore[call-arg]
+        assert settings.port == 8000
+
+    def test_default_storage_dir(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LINE_CHANNEL_SECRET", "s")
+        monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "t")
+        settings = Settings()  # type: ignore[call-arg]
+        assert settings.storage_dir == Path.home() / ".ai-journaling-agent" / "data"
+
+
+class TestSettingsOverride:
+    """Environment variables override defaults."""
+
+    def test_override_port(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LINE_CHANNEL_SECRET", "s")
+        monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "t")
+        monkeypatch.setenv("PORT", "9999")
+        settings = Settings()  # type: ignore[call-arg]
+        assert settings.port == 9999
+
+    def test_override_storage_dir(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LINE_CHANNEL_SECRET", "s")
+        monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "t")
+        monkeypatch.setenv("STORAGE_DIR", "/tmp/test-data")
+        settings = Settings()  # type: ignore[call-arg]
+        assert settings.storage_dir == Path("/tmp/test-data")

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "line-bot-sdk" },
+    { name = "pydantic-settings" },
 ]
 
 [package.dev-dependencies]
@@ -27,7 +28,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "line-bot-sdk", specifier = ">=3.0" }]
+requires-dist = [
+    { name = "line-bot-sdk", specifier = ">=3.0" },
+    { name = "pydantic-settings", specifier = ">=2.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -782,6 +786,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -816,6 +834,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `Settings` class with pydantic-settings for LINE credentials, storage_dir, port configuration
- `.env.example` template for required environment variables
- Tests covering required field validation, defaults, and overrides
- `.gitignore` updated to exclude `.mypy_cache/`, `.pytest_cache/`, `.ruff_cache/`

Closes #1

## Test plan
- [x] `uv run pytest tests/test_config.py -v` — 6 tests pass
- [x] `uv run ruff check` — all checks passed
- [x] `uv run mypy src/ai_journaling_agent/core/config.py` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)