### PR TITLE
feat: add JSON persistence layer (JournalRepository)

### DIFF
--- a/src/ai_journaling_agent/core/journal.py
+++ b/src/ai_journaling_agent/core/journal.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import IntEnum
-from typing import Optional
+from typing import Any
 
 
 class EntryLevel(IntEnum):
@@ -22,9 +22,36 @@ class JournalEntry:
 
     timestamp: datetime
     level: EntryLevel
-    emoji: Optional[str] = None
-    summary: Optional[str] = None
+    emoji: str | None = None
+    summary: str | None = None
     achievements: list[str] = field(default_factory=list)
     gratitude: list[str] = field(default_factory=list)
     learnings: list[str] = field(default_factory=list)
     photo_paths: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize to a JSON-compatible dictionary."""
+        return {
+            "timestamp": self.timestamp.isoformat(),
+            "level": int(self.level),
+            "emoji": self.emoji,
+            "summary": self.summary,
+            "achievements": self.achievements,
+            "gratitude": self.gratitude,
+            "learnings": self.learnings,
+            "photo_paths": self.photo_paths,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> JournalEntry:
+        """Deserialize from a dictionary."""
+        return cls(
+            timestamp=datetime.fromisoformat(data["timestamp"]),
+            level=EntryLevel(data["level"]),
+            emoji=data.get("emoji"),
+            summary=data.get("summary"),
+            achievements=list(data.get("achievements") or []),
+            gratitude=list(data.get("gratitude") or []),
+            learnings=list(data.get("learnings") or []),
+            photo_paths=list(data.get("photo_paths") or []),
+        )

--- a/src/ai_journaling_agent/core/repository.py
+++ b/src/ai_journaling_agent/core/repository.py
@@ -1,0 +1,72 @@
+"""Journal entry persistence layer."""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+from typing import Protocol
+
+from ai_journaling_agent.core.journal import JournalEntry
+
+
+class JournalRepository(Protocol):
+    """Abstract repository for journal entries."""
+
+    def save(self, user_id: str, entry: JournalEntry) -> None: ...
+
+    def list_entries(
+        self, user_id: str, *, date: date | None = None
+    ) -> list[JournalEntry]: ...
+
+    def get_latest(self, user_id: str) -> JournalEntry | None: ...
+
+
+class JsonJournalRepository:
+    """JSONL-based repository. One file per user: {storage_dir}/{user_id}.jsonl"""
+
+    def __init__(self, storage_dir: Path) -> None:
+        self._storage_dir = storage_dir
+
+    def _user_file(self, user_id: str) -> Path:
+        return self._storage_dir / f"{user_id}.jsonl"
+
+    def save(self, user_id: str, entry: JournalEntry) -> None:
+        """Append a journal entry to the user's JSONL file."""
+        self._storage_dir.mkdir(parents=True, exist_ok=True)
+        with self._user_file(user_id).open("a", encoding="utf-8") as f:
+            f.write(json.dumps(entry.to_dict(), ensure_ascii=False) + "\n")
+
+    def list_entries(
+        self, user_id: str, *, date: date | None = None
+    ) -> list[JournalEntry]:
+        """Load all entries for a user, optionally filtered by date."""
+        path = self._user_file(user_id)
+        if not path.exists():
+            return []
+        entries: list[JournalEntry] = []
+        with path.open(encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                entry = JournalEntry.from_dict(json.loads(line))
+                if date is not None and entry.timestamp.date() != date:
+                    continue
+                entries.append(entry)
+        return entries
+
+    def get_latest(self, user_id: str) -> JournalEntry | None:
+        """Return the most recent entry for a user, or None."""
+        path = self._user_file(user_id)
+        if not path.exists():
+            return None
+        last_line = ""
+        with path.open(encoding="utf-8") as f:
+            for line in f:
+                stripped = line.strip()
+                if stripped:
+                    last_line = stripped
+        if not last_line:
+            return None
+        return JournalEntry.from_dict(json.loads(last_line))

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -1,0 +1,76 @@
+"""Tests for JournalEntry serialization."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from ai_journaling_agent.core.journal import EntryLevel, JournalEntry
+
+
+class TestToDict:
+    """to_dict produces expected output."""
+
+    def test_full_entry(self) -> None:
+        entry = JournalEntry(
+            timestamp=datetime(2026, 3, 15, 9, 0, 0),
+            level=EntryLevel.STRUCTURED,
+            emoji="😊",
+            summary="良い一日",
+            achievements=["朝ラン5km"],
+            gratitude=["天気が良かった"],
+            learnings=["新しいAPI"],
+            photo_paths=["/tmp/photo.jpg"],
+        )
+        d = entry.to_dict()
+        assert d["timestamp"] == "2026-03-15T09:00:00"
+        assert d["level"] == 2
+        assert d["emoji"] == "😊"
+        assert d["summary"] == "良い一日"
+        assert d["achievements"] == ["朝ラン5km"]
+
+    def test_emoji_only_entry(self) -> None:
+        entry = JournalEntry(
+            timestamp=datetime(2026, 3, 15, 21, 0, 0),
+            level=EntryLevel.EMOJI,
+            emoji="😴",
+        )
+        d = entry.to_dict()
+        assert d["level"] == 0
+        assert d["summary"] is None
+        assert d["achievements"] == []
+
+
+class TestRoundTrip:
+    """to_dict -> from_dict preserves all fields."""
+
+    def test_structured_round_trip(self) -> None:
+        original = JournalEntry(
+            timestamp=datetime(2026, 3, 15, 9, 30, 0),
+            level=EntryLevel.STRUCTURED,
+            emoji="🎉",
+            summary="素晴らしい日",
+            achievements=["プレゼン成功", "コードレビュー"],
+            gratitude=["チームのサポート"],
+            learnings=["設計パターン"],
+            photo_paths=["/tmp/a.jpg", "/tmp/b.jpg"],
+        )
+        restored = JournalEntry.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_emoji_round_trip(self) -> None:
+        original = JournalEntry(
+            timestamp=datetime(2026, 3, 15, 7, 0, 0),
+            level=EntryLevel.EMOJI,
+            emoji="☀️",
+        )
+        restored = JournalEntry.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_summary_round_trip(self) -> None:
+        original = JournalEntry(
+            timestamp=datetime(2026, 3, 15, 12, 0, 0),
+            level=EntryLevel.SUMMARY,
+            summary="まあまあの日",
+        )
+        restored = JournalEntry.from_dict(original.to_dict())
+        assert restored == original

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,0 +1,93 @@
+"""Tests for JsonJournalRepository."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from pathlib import Path
+
+from ai_journaling_agent.core.journal import EntryLevel, JournalEntry
+from ai_journaling_agent.core.repository import JsonJournalRepository
+
+
+def _make_entry(
+    ts: datetime,
+    level: EntryLevel = EntryLevel.EMOJI,
+    emoji: str | None = "😊",
+) -> JournalEntry:
+    return JournalEntry(timestamp=ts, level=level, emoji=emoji)
+
+
+class TestSaveAndLoad:
+    """save -> list_entries round trip."""
+
+    def test_save_and_list(self, tmp_path: Path) -> None:
+        repo = JsonJournalRepository(tmp_path)
+        entry = _make_entry(datetime(2026, 3, 15, 9, 0, 0))
+        repo.save("user1", entry)
+        entries = repo.list_entries("user1")
+        assert len(entries) == 1
+        assert entries[0] == entry
+
+    def test_multiple_entries(self, tmp_path: Path) -> None:
+        repo = JsonJournalRepository(tmp_path)
+        e1 = _make_entry(datetime(2026, 3, 15, 9, 0, 0), emoji="☀️")
+        e2 = _make_entry(datetime(2026, 3, 15, 21, 0, 0), emoji="🌙")
+        repo.save("user1", e1)
+        repo.save("user1", e2)
+        entries = repo.list_entries("user1")
+        assert len(entries) == 2
+        assert entries[0] == e1
+        assert entries[1] == e2
+
+    def test_separate_users(self, tmp_path: Path) -> None:
+        repo = JsonJournalRepository(tmp_path)
+        e1 = _make_entry(datetime(2026, 3, 15, 9, 0, 0))
+        e2 = _make_entry(datetime(2026, 3, 15, 10, 0, 0))
+        repo.save("alice", e1)
+        repo.save("bob", e2)
+        assert len(repo.list_entries("alice")) == 1
+        assert len(repo.list_entries("bob")) == 1
+
+
+class TestDateFilter:
+    """list_entries with date filter."""
+
+    def test_filter_by_date(self, tmp_path: Path) -> None:
+        repo = JsonJournalRepository(tmp_path)
+        e_mar15 = _make_entry(datetime(2026, 3, 15, 9, 0, 0))
+        e_mar16 = _make_entry(datetime(2026, 3, 16, 9, 0, 0))
+        repo.save("user1", e_mar15)
+        repo.save("user1", e_mar16)
+        result = repo.list_entries("user1", date=date(2026, 3, 15))
+        assert len(result) == 1
+        assert result[0] == e_mar15
+
+    def test_filter_no_match(self, tmp_path: Path) -> None:
+        repo = JsonJournalRepository(tmp_path)
+        repo.save("user1", _make_entry(datetime(2026, 3, 15, 9, 0, 0)))
+        result = repo.list_entries("user1", date=date(2026, 1, 1))
+        assert result == []
+
+
+class TestGetLatest:
+    """get_latest returns the most recent entry."""
+
+    def test_returns_latest(self, tmp_path: Path) -> None:
+        repo = JsonJournalRepository(tmp_path)
+        repo.save("user1", _make_entry(datetime(2026, 3, 15, 9, 0, 0), emoji="☀️"))
+        repo.save("user1", _make_entry(datetime(2026, 3, 15, 21, 0, 0), emoji="🌙"))
+        latest = repo.get_latest("user1")
+        assert latest is not None
+        assert latest.emoji == "🌙"
+
+    def test_unknown_user_returns_none(self, tmp_path: Path) -> None:
+        repo = JsonJournalRepository(tmp_path)
+        assert repo.get_latest("unknown") is None
+
+
+class TestUnknownUser:
+    """Operations on non-existent users."""
+
+    def test_list_entries_empty(self, tmp_path: Path) -> None:
+        repo = JsonJournalRepository(tmp_path)
+        assert repo.list_entries("nonexistent") == []


### PR DESCRIPTION
## Summary
- `JournalEntry.to_dict()` / `from_dict()` for serialization
- `JournalRepository` Protocol + `JsonJournalRepository` (JSONL format, one file per user)
- 13 tests covering round-trip serialization, save/load, date filter, get_latest, unknown user handling
- `Optional[str]` → `str | None` migration (ruff UP045)

Closes #2

## Test plan
- [x] `uv run pytest tests/test_journal.py tests/test_repository.py -v` — 13 tests pass
- [x] `uv run ruff check` — all checks passed
- [x] `uv run mypy src/ai_journaling_agent/core/` — no issues (strict mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)