### PR TITLE
feat: add check-in prompts and user lifecycle management

### DIFF
--- a/src/ai_journaling_agent/adapters/line/bot.py
+++ b/src/ai_journaling_agent/adapters/line/bot.py
@@ -14,14 +14,17 @@ from linebot.v3.webhooks import (  # type: ignore[import-untyped]
     FollowEvent,
     MessageEvent,
     TextMessageContent,
+    UnfollowEvent,
 )
 
 from ai_journaling_agent.adapters.line.handlers import (
     handle_follow_event,
     handle_message_event,
+    handle_unfollow_event,
 )
 from ai_journaling_agent.core.config import Settings
 from ai_journaling_agent.core.repository import JsonJournalRepository
+from ai_journaling_agent.core.user import JsonUserRepository
 
 
 def create_app(settings: Settings) -> FastAPI:
@@ -31,6 +34,7 @@ def create_app(settings: Settings) -> FastAPI:
     parser = WebhookParser(channel_secret=settings.line_channel_secret)
     configuration = Configuration(access_token=settings.line_channel_access_token)
     repository = JsonJournalRepository(settings.storage_dir)
+    user_repository = JsonUserRepository(settings.storage_dir)
 
     @app.post("/callback")
     async def callback(request: Request) -> dict[str, str]:
@@ -48,9 +52,13 @@ def create_app(settings: Settings) -> FastAPI:
                 if isinstance(event, MessageEvent) and isinstance(
                     event.message, TextMessageContent
                 ):
-                    await handle_message_event(event, line_api, repository)
+                    await handle_message_event(
+                        event, line_api, repository, user_repository
+                    )
                 elif isinstance(event, FollowEvent):
-                    await handle_follow_event(event, line_api)
+                    await handle_follow_event(event, line_api, user_repository)
+                elif isinstance(event, UnfollowEvent):
+                    await handle_unfollow_event(event, user_repository)
 
         return {"status": "ok"}
 

--- a/src/ai_journaling_agent/adapters/line/handlers.py
+++ b/src/ai_journaling_agent/adapters/line/handlers.py
@@ -9,33 +9,44 @@ from linebot.v3.messaging import (  # type: ignore[import-untyped]
     ReplyMessageRequest,
     TextMessage,
 )
-from linebot.v3.webhooks import FollowEvent, MessageEvent  # type: ignore[import-untyped]
+from linebot.v3.webhooks import FollowEvent, MessageEvent, UnfollowEvent  # type: ignore[import-untyped]
 
 from ai_journaling_agent.core.classifier import classify_message, parse_structured_entry
 from ai_journaling_agent.core.journal import EntryLevel, JournalEntry
 from ai_journaling_agent.core.prompts import WELCOME_BACK
 from ai_journaling_agent.core.repository import JournalRepository
 from ai_journaling_agent.core.responses import generate_response
+from ai_journaling_agent.core.scheduler import get_check_in_prompt
+from ai_journaling_agent.core.user import UserRepository, UserState
 
 
 async def handle_message_event(
     event: MessageEvent,
     line_api: AsyncMessagingApi,
     repository: JournalRepository,
+    user_repository: UserRepository,
 ) -> None:
     """Handle incoming text messages.
 
     Classifies the message, creates a journal entry, and replies.
+    Appends a check-in prompt when the time of day matches.
     """
     user_id: str = event.source.user_id
     text: str = event.message.text
+    now = datetime.now(tz=UTC)
+
+    # Update user last_interaction
+    user_state = user_repository.get(user_id)
+    if user_state is not None:
+        user_state.last_interaction = now
+        user_repository.save(user_state)
 
     level = classify_message(text)
 
     if level == EntryLevel.STRUCTURED:
         parsed = parse_structured_entry(text)
         entry = JournalEntry(
-            timestamp=datetime.now(tz=UTC),
+            timestamp=now,
             level=level,
             summary=text,
             achievements=parsed["achievements"],
@@ -44,13 +55,13 @@ async def handle_message_event(
         )
     elif level == EntryLevel.EMOJI:
         entry = JournalEntry(
-            timestamp=datetime.now(tz=UTC),
+            timestamp=now,
             level=level,
             emoji=text.strip(),
         )
     else:
         entry = JournalEntry(
-            timestamp=datetime.now(tz=UTC),
+            timestamp=now,
             level=level,
             summary=text,
         )
@@ -58,6 +69,11 @@ async def handle_message_event(
     repository.save(user_id, entry)
 
     reply_text = generate_response(entry)
+
+    check_in = get_check_in_prompt(now.hour)
+    if check_in:
+        reply_text += "\n\n" + check_in
+
     await line_api.reply_message(
         ReplyMessageRequest(
             reply_token=event.reply_token,
@@ -69,11 +85,44 @@ async def handle_message_event(
 async def handle_follow_event(
     event: FollowEvent,
     line_api: AsyncMessagingApi,
+    user_repository: UserRepository,
 ) -> None:
     """Handle follow (friend add) events with welcome message."""
+    now = datetime.now(tz=UTC)
+    user_id: str = event.source.user_id
+
+    user_state = user_repository.get(user_id)
+    if user_state is not None:
+        # Re-follow: reactivate
+        user_state.is_active = True
+        user_state.last_interaction = now
+        user_repository.save(user_state)
+    else:
+        # New user
+        user_repository.save(
+            UserState(
+                user_id=user_id,
+                is_active=True,
+                created_at=now,
+                last_interaction=now,
+            )
+        )
+
     await line_api.reply_message(
         ReplyMessageRequest(
             reply_token=event.reply_token,
             messages=[TextMessage(text=WELCOME_BACK)],
         )
     )
+
+
+async def handle_unfollow_event(
+    event: UnfollowEvent,
+    user_repository: UserRepository,
+) -> None:
+    """Handle unfollow (block) events by deactivating the user."""
+    user_id: str = event.source.user_id
+    user_state = user_repository.get(user_id)
+    if user_state is not None:
+        user_state.is_active = False
+        user_repository.save(user_state)

--- a/src/ai_journaling_agent/core/scheduler.py
+++ b/src/ai_journaling_agent/core/scheduler.py
@@ -1,0 +1,19 @@
+"""Time-based check-in prompt selection."""
+
+from __future__ import annotations
+
+from ai_journaling_agent.core.prompts import EVENING_CHECK_IN, MORNING_CHECK_IN
+
+
+def get_check_in_prompt(hour: int) -> str | None:
+    """Return a check-in prompt based on the hour of day, or None.
+
+    - 06:00–09:59 → morning check-in
+    - 18:00–21:59 → evening check-in
+    - Otherwise → None
+    """
+    if 6 <= hour < 10:
+        return MORNING_CHECK_IN
+    if 18 <= hour < 22:
+        return EVENING_CHECK_IN
+    return None

--- a/src/ai_journaling_agent/core/user.py
+++ b/src/ai_journaling_agent/core/user.py
@@ -1,0 +1,70 @@
+"""User state management for lifecycle tracking."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Protocol
+
+
+@dataclass
+class UserState:
+    """Represents a user's lifecycle state."""
+
+    user_id: str
+    is_active: bool
+    created_at: datetime
+    last_interaction: datetime
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize to a JSON-compatible dictionary."""
+        return {
+            "user_id": self.user_id,
+            "is_active": self.is_active,
+            "created_at": self.created_at.isoformat(),
+            "last_interaction": self.last_interaction.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> UserState:
+        """Deserialize from a dictionary."""
+        return cls(
+            user_id=data["user_id"],
+            is_active=data["is_active"],
+            created_at=datetime.fromisoformat(data["created_at"]),
+            last_interaction=datetime.fromisoformat(data["last_interaction"]),
+        )
+
+
+class UserRepository(Protocol):
+    """Abstract repository for user state."""
+
+    def get(self, user_id: str) -> UserState | None: ...
+
+    def save(self, state: UserState) -> None: ...
+
+
+class JsonUserRepository:
+    """JSON-based user repository. One file per user: {storage_dir}/users/{user_id}.json"""
+
+    def __init__(self, storage_dir: Path) -> None:
+        self._storage_dir = storage_dir / "users"
+
+    def _user_file(self, user_id: str) -> Path:
+        return self._storage_dir / f"{user_id}.json"
+
+    def get(self, user_id: str) -> UserState | None:
+        """Load user state, or None if not found."""
+        path = self._user_file(user_id)
+        if not path.exists():
+            return None
+        with path.open(encoding="utf-8") as f:
+            return UserState.from_dict(json.loads(f.read()))
+
+    def save(self, state: UserState) -> None:
+        """Save user state (overwrites existing)."""
+        self._storage_dir.mkdir(parents=True, exist_ok=True)
+        with self._user_file(state.user_id).open("w", encoding="utf-8") as f:
+            f.write(json.dumps(state.to_dict(), ensure_ascii=False))

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,138 @@
+"""Integration tests for user lifecycle (Follow / Unfollow / Message)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from linebot.v3.webhooks import (  # type: ignore[import-untyped]
+    FollowEvent,
+    MessageEvent,
+    Source,
+    TextMessageContent,
+    UnfollowEvent,
+)
+
+from ai_journaling_agent.adapters.line.handlers import (
+    handle_follow_event,
+    handle_message_event,
+    handle_unfollow_event,
+)
+from ai_journaling_agent.core.user import JsonUserRepository, UserState
+
+
+def _make_source(user_id: str) -> MagicMock:
+    source = MagicMock(spec=Source)
+    source.user_id = user_id
+    return source
+
+
+def _make_follow_event(user_id: str) -> MagicMock:
+    event = MagicMock(spec=FollowEvent)
+    event.source = _make_source(user_id)
+    event.reply_token = "test-reply-token"
+    return event
+
+
+def _make_unfollow_event(user_id: str) -> MagicMock:
+    event = MagicMock(spec=UnfollowEvent)
+    event.source = _make_source(user_id)
+    return event
+
+
+def _make_message_event(user_id: str, text: str) -> MagicMock:
+    event = MagicMock(spec=MessageEvent)
+    event.source = _make_source(user_id)
+    event.message = MagicMock(spec=TextMessageContent)
+    event.message.text = text
+    event.reply_token = "test-reply-token"
+    return event
+
+
+class TestFollowLifecycle:
+    """Follow creates user state and sends welcome message."""
+
+    @pytest.mark.asyncio
+    async def test_follow_creates_user(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        user_repo = JsonUserRepository(Path(str(tmp_path)))
+        line_api = AsyncMock()
+        event = _make_follow_event("U1234")
+
+        await handle_follow_event(event, line_api, user_repo)
+
+        state = user_repo.get("U1234")
+        assert state is not None
+        assert state.is_active is True
+        assert state.user_id == "U1234"
+        line_api.reply_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_refollow_reactivates_user(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        path = Path(str(tmp_path))
+        user_repo = JsonUserRepository(path)
+        now = datetime(2026, 3, 15, 9, 0, 0, tzinfo=UTC)
+        user_repo.save(UserState("U1234", False, now, now))
+
+        line_api = AsyncMock()
+        event = _make_follow_event("U1234")
+        await handle_follow_event(event, line_api, user_repo)
+
+        state = user_repo.get("U1234")
+        assert state is not None
+        assert state.is_active is True
+
+
+class TestUnfollowLifecycle:
+    """Unfollow deactivates user without deleting data."""
+
+    @pytest.mark.asyncio
+    async def test_unfollow_deactivates_user(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        path = Path(str(tmp_path))
+        user_repo = JsonUserRepository(path)
+        now = datetime(2026, 3, 15, 9, 0, 0, tzinfo=UTC)
+        user_repo.save(UserState("U1234", True, now, now))
+
+        event = _make_unfollow_event("U1234")
+        await handle_unfollow_event(event, user_repo)
+
+        state = user_repo.get("U1234")
+        assert state is not None
+        assert state.is_active is False
+
+    @pytest.mark.asyncio
+    async def test_unfollow_unknown_user_is_noop(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        user_repo = JsonUserRepository(Path(str(tmp_path)))
+        event = _make_unfollow_event("U9999")
+        # Should not raise
+        await handle_unfollow_event(event, user_repo)
+
+
+class TestMessageUpdatesInteraction:
+    """Message events update last_interaction timestamp."""
+
+    @pytest.mark.asyncio
+    async def test_message_updates_last_interaction(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        path = Path(str(tmp_path))
+        user_repo = JsonUserRepository(path)
+        journal_repo = MagicMock()
+        old_time = datetime(2026, 3, 14, 9, 0, 0, tzinfo=UTC)
+        user_repo.save(UserState("U1234", True, old_time, old_time))
+
+        line_api = AsyncMock()
+        event = _make_message_event("U1234", "今日は良い日")
+        await handle_message_event(event, line_api, journal_repo, user_repo)
+
+        state = user_repo.get("U1234")
+        assert state is not None
+        assert state.last_interaction > old_time

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,52 @@
+"""Tests for time-based check-in prompt selection."""
+
+from __future__ import annotations
+
+import pytest
+
+from ai_journaling_agent.core.prompts import EVENING_CHECK_IN, MORNING_CHECK_IN
+from ai_journaling_agent.core.scheduler import get_check_in_prompt
+
+
+class TestGetCheckInPrompt:
+    """get_check_in_prompt returns the correct prompt for the hour."""
+
+    @pytest.mark.parametrize(
+        ("hour", "expected"),
+        [
+            (6, MORNING_CHECK_IN),
+            (7, MORNING_CHECK_IN),
+            (9, MORNING_CHECK_IN),
+            (18, EVENING_CHECK_IN),
+            (20, EVENING_CHECK_IN),
+            (21, EVENING_CHECK_IN),
+        ],
+        ids=[
+            "morning_start_6",
+            "morning_mid_7",
+            "morning_end_9",
+            "evening_start_18",
+            "evening_mid_20",
+            "evening_end_21",
+        ],
+    )
+    def test_check_in_hours(self, hour: int, expected: str) -> None:
+        assert get_check_in_prompt(hour) == expected
+
+    @pytest.mark.parametrize(
+        "hour",
+        [0, 3, 5, 10, 12, 14, 17, 22, 23],
+        ids=[
+            "midnight_0",
+            "early_3",
+            "before_morning_5",
+            "after_morning_10",
+            "noon_12",
+            "afternoon_14",
+            "before_evening_17",
+            "after_evening_22",
+            "late_night_23",
+        ],
+    )
+    def test_no_check_in_hours(self, hour: int) -> None:
+        assert get_check_in_prompt(hour) is None

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,0 +1,92 @@
+"""Tests for user state management."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from ai_journaling_agent.core.user import JsonUserRepository, UserState
+
+
+class TestUserState:
+    """UserState serialization round-trips correctly."""
+
+    def test_to_dict_and_from_dict(self) -> None:
+        now = datetime(2026, 3, 15, 9, 0, 0, tzinfo=UTC)
+        state = UserState(
+            user_id="U1234",
+            is_active=True,
+            created_at=now,
+            last_interaction=now,
+        )
+        data = state.to_dict()
+        restored = UserState.from_dict(data)
+        assert restored.user_id == "U1234"
+        assert restored.is_active is True
+        assert restored.created_at == now
+        assert restored.last_interaction == now
+
+    def test_inactive_state_round_trip(self) -> None:
+        now = datetime(2026, 3, 15, 9, 0, 0, tzinfo=UTC)
+        state = UserState(
+            user_id="U5678",
+            is_active=False,
+            created_at=now,
+            last_interaction=now,
+        )
+        restored = UserState.from_dict(state.to_dict())
+        assert restored.is_active is False
+
+
+class TestJsonUserRepository:
+    """JsonUserRepository persists user state to disk."""
+
+    def test_save_and_get(self, tmp_path: Path) -> None:
+        repo = JsonUserRepository(tmp_path)
+        now = datetime(2026, 3, 15, 9, 0, 0, tzinfo=UTC)
+        state = UserState(
+            user_id="U1234",
+            is_active=True,
+            created_at=now,
+            last_interaction=now,
+        )
+        repo.save(state)
+
+        loaded = repo.get("U1234")
+        assert loaded is not None
+        assert loaded.user_id == "U1234"
+        assert loaded.is_active is True
+
+    def test_get_nonexistent_returns_none(self, tmp_path: Path) -> None:
+        repo = JsonUserRepository(tmp_path)
+        assert repo.get("U9999") is None
+
+    def test_save_overwrites_existing(self, tmp_path: Path) -> None:
+        repo = JsonUserRepository(tmp_path)
+        now = datetime(2026, 3, 15, 9, 0, 0, tzinfo=UTC)
+        state = UserState(
+            user_id="U1234",
+            is_active=True,
+            created_at=now,
+            last_interaction=now,
+        )
+        repo.save(state)
+
+        state.is_active = False
+        repo.save(state)
+
+        loaded = repo.get("U1234")
+        assert loaded is not None
+        assert loaded.is_active is False
+
+    def test_multiple_users_independent(self, tmp_path: Path) -> None:
+        repo = JsonUserRepository(tmp_path)
+        now = datetime(2026, 3, 15, 9, 0, 0, tzinfo=UTC)
+
+        repo.save(UserState("U001", True, now, now))
+        repo.save(UserState("U002", False, now, now))
+
+        assert repo.get("U001") is not None
+        assert repo.get("U001").is_active is True  # type: ignore[union-attr]
+        assert repo.get("U002") is not None
+        assert repo.get("U002").is_active is False  # type: ignore[union-attr]

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -37,8 +37,10 @@ def _make_message_event(user_id: str, text: str) -> MagicMock:
     return event
 
 
-def _make_follow_event() -> MagicMock:
+def _make_follow_event(user_id: str = "U0000") -> MagicMock:
     event = MagicMock(spec=FollowEvent)
+    event.source = MagicMock(spec=Source)
+    event.source.user_id = user_id
     event.reply_token = "test-reply-token"
     return event
 


### PR DESCRIPTION
## Summary
- `core/user.py`: `UserState` dataclass + `UserRepository` Protocol + `JsonUserRepository` (JSON per user, overwrite semantics)
- `core/scheduler.py`: `get_check_in_prompt(hour)` — 朝6-10時/夜18-22時にチェックインプロンプトを付与
- `handlers.py`: Follow→ユーザー作成、Unfollow→非アクティブ化、Message→last_interaction更新+チェックイン文脈付与
- `bot.py`: `UnfollowEvent` dispatch + `JsonUserRepository` 注入

## Test plan
- [x] `test_user.py`: UserState往復テスト + JsonUserRepository CRUD (6 tests)
- [x] `test_scheduler.py`: 時間帯→プロンプト判定 + 境界値 (15 tests)
- [x] `test_lifecycle.py`: Follow/Unfollow/Message統合テスト (5 tests)
- [x] 既存テスト（test_webhook等）がシグネチャ変更後も通過
- [x] `ruff check` + `mypy --strict` 通過

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)