### PR TITLE
chore: add .claude/scheduled_tasks.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,8 @@ outputs/
 .env.*
 !.env.example
 
+# Claude Code
+.claude/scheduled_tasks.lock
+
 # OS
 .DS_Store


### PR DESCRIPTION
## Summary
- Claude Code `/loop` が生成するロックファイルを `.gitignore` に追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)