### PR TITLE
chore: jj auto-track-bookmarks 設定で deprecated 警告を解消

### DIFF
--- a/.claude/skills/common/jj-workflow.md
+++ b/.claude/skills/common/jj-workflow.md
@@ -17,3 +17,4 @@ jj git push                # リモートにプッシュ
 - `git` コマンドは直接使わない。`jj` 経由で操作する
 - `jj new` で作業を始め、`jj describe` で完了を記録
 - outputs/ はjj管理外（.gitignoreで除外済み）
+- `remotes.origin.auto-track-bookmarks = "glob:*"` を設定済み。`jj git push` で新規ブックマークも自動トラッキングされるため、`--allow-new` フラグは不要


### PR DESCRIPTION
## Summary
- `remotes.origin.auto-track-bookmarks = "glob:*"` をリポジトリ設定に追加
- `jj git push --allow-new` の deprecated 警告を解消
- `.claude/skills/common/jj-workflow.md` に設定済みである旨を追記

Closes #22