### PR TITLE
feat: add UserProfile data model and mood trend visualization (#32, #35)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ push-line = "ai_journaling_agent.cli.push_cmd:main"
 journal-history = "ai_journaling_agent.cli.history_cmd:main"
 checkin = "ai_journaling_agent.cli.checkin_cmd:main"
 journal-today = "ai_journaling_agent.cli.today_cmd:main"
+mood-report = "ai_journaling_agent.cli.mood_report_cmd:main"
+retrospective = "ai_journaling_agent.cli.retrospective_cmd:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/ai_journaling_agent/adapters/line/bot.py
+++ b/src/ai_journaling_agent/adapters/line/bot.py
@@ -30,6 +30,9 @@ from ai_journaling_agent.core.config import Settings
 from ai_journaling_agent.core.inbox import JsonInboxRepository
 from ai_journaling_agent.core.repository import JsonJournalRepository
 from ai_journaling_agent.core.user import JsonUserRepository
+from ai_journaling_agent.core.user_profile import JsonUserProfileRepository, UserProfile
+
+PROFILE_UPDATE_INTERVAL = 5
 
 
 async def _respond_to_user(
@@ -38,10 +41,12 @@ async def _respond_to_user(
     responder: AiResponder,
     access_token: str,
     checkin_tracker: CheckInTracker,
+    profile_repository: JsonUserProfileRepository,
 ) -> None:
     """Background task: generate AI response and push to LINE."""
+    profile = profile_repository.get(user_id)
     checkin_prompt = checkin_tracker.get_recent_prompt()
-    response = await responder.generate_response(user_id, user_text, checkin_prompt=checkin_prompt)
+    response = await responder.generate_response(user_id, user_text, checkin_prompt=checkin_prompt, profile=profile)
     configuration = Configuration(access_token=access_token)
     async with AsyncApiClient(configuration) as api_client:
         line_api = AsyncMessagingApi(api_client)
@@ -51,6 +56,14 @@ async def _respond_to_user(
                 messages=[TextMessage(text=response)],
             )
         )
+    # Profile auto-update
+    if profile is None:
+        profile = UserProfile(user_id=user_id)
+    profile.profile_update_counter += 1
+    if profile.profile_update_counter % PROFILE_UPDATE_INTERVAL == 0:
+        from ai_journaling_agent.core.profile_extractor import extract_profile_updates
+        profile = await extract_profile_updates(user_text, profile, responder)
+    profile_repository.save(profile)
 
 
 def create_app(settings: Settings) -> FastAPI:
@@ -66,6 +79,7 @@ def create_app(settings: Settings) -> FastAPI:
         storage_dir=settings.storage_dir,
     )
     checkin_tracker = CheckInTracker(settings.storage_dir)
+    profile_repository = JsonUserProfileRepository(settings.storage_dir)
 
     @app.get("/health")
     async def health() -> dict[str, str]:
@@ -98,6 +112,7 @@ def create_app(settings: Settings) -> FastAPI:
                         responder=responder,
                         access_token=settings.line_channel_access_token,
                         checkin_tracker=checkin_tracker,
+                        profile_repository=profile_repository,
                     )
                 elif isinstance(event, FollowEvent):
                     await handle_follow_event(event, line_api, user_repository)

--- a/src/ai_journaling_agent/adapters/line/handlers.py
+++ b/src/ai_journaling_agent/adapters/line/handlers.py
@@ -14,9 +14,13 @@ from linebot.v3.webhooks import FollowEvent, MessageEvent, UnfollowEvent  # type
 from ai_journaling_agent.core.classifier import classify_message, emoji_to_mood, parse_structured_entry
 from ai_journaling_agent.core.inbox import InboxMessage, InboxRepository, generate_message_id
 from ai_journaling_agent.core.journal import EntryLevel, JournalEntry
+from ai_journaling_agent.core.mood import format_mood_timeline, get_mood_trend
 from ai_journaling_agent.core.prompts import WELCOME_BACK
 from ai_journaling_agent.core.repository import JournalRepository
 from ai_journaling_agent.core.user import UserRepository, UserState
+
+_MOOD_KEYWORDS = {"気分の波", "ムード", "きぶんのなみ"}
+_RETROSPECTIVE_KEYWORDS = {"今週のふりかえり", "ふりかえり", "振り返り"}
 
 
 async def handle_message_event(
@@ -34,6 +38,38 @@ async def handle_message_event(
     user_id: str = event.source.user_id
     text: str = event.message.text
     now = datetime.now(tz=UTC)
+
+    # Mood trend keyword detection — reply immediately and skip journal save
+    if any(kw in text for kw in _MOOD_KEYWORDS):
+        trend = get_mood_trend(repository, user_id)
+        timeline = format_mood_timeline(trend)
+        await line_api.reply_message(
+            ReplyMessageRequest(
+                reply_token=event.reply_token,
+                messages=[TextMessage(text=f"直近7日間の気分の波:\n{timeline}")],
+            )
+        )
+        return
+
+    # Retrospective keyword detection — reply immediately and skip journal save
+    if any(kw in text for kw in _RETROSPECTIVE_KEYWORDS):
+        from datetime import timedelta
+        today = now.date()
+        week_start = today - timedelta(days=6)
+        week_end = today
+        from ai_journaling_agent.core.retrospective import _collect_entries_text
+        entries_text = _collect_entries_text(repository, user_id, week_start, week_end)
+        if entries_text:
+            reply_text = f"今週のふりかえり:\n{entries_text}"
+        else:
+            reply_text = "今週の記録はまだありませんでした。"
+        await line_api.reply_message(
+            ReplyMessageRequest(
+                reply_token=event.reply_token,
+                messages=[TextMessage(text=reply_text)],
+            )
+        )
+        return
 
     # Update user last_interaction
     user_state = user_repository.get(user_id)

--- a/src/ai_journaling_agent/cli/mood_report_cmd.py
+++ b/src/ai_journaling_agent/cli/mood_report_cmd.py
@@ -1,0 +1,32 @@
+"""CLI for viewing mood trend report."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from ai_journaling_agent.core.config import Settings
+from ai_journaling_agent.core.mood import format_mood_timeline, get_mood_trend
+from ai_journaling_agent.core.repository import JsonJournalRepository
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Show mood trend report")
+    parser.add_argument("--user", help="LINE user ID (defaults to OWNER_USER_ID)")
+    parser.add_argument("--days", type=int, default=7, help="Number of days to show (default: 7)")
+
+    args = parser.parse_args(argv)
+    settings = Settings()  # type: ignore[call-arg]
+
+    user_id = args.user or settings.owner_user_id
+    if not user_id:
+        print("Error: --user required or set OWNER_USER_ID in .env", file=sys.stderr)
+        sys.exit(1)
+
+    repo = JsonJournalRepository(settings.storage_dir)
+    trend = get_mood_trend(repo, user_id, days=args.days)
+    print(format_mood_timeline(trend))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/src/ai_journaling_agent/core/ai_responder.py
+++ b/src/ai_journaling_agent/core/ai_responder.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from claude_agent_sdk import AssistantMessage, ClaudeAgentOptions, ResultMessage, TextBlock, query
+
+if TYPE_CHECKING:
+    from ai_journaling_agent.core.user_profile import UserProfile
 
 SYSTEM_PROMPT = """あなたはジャーナリングパートナーです。ユーザーの日々の記録を手伝います。
 
@@ -53,15 +57,32 @@ class AiResponder:
     def _save_session_id(self, user_id: str, session_id: str) -> None:
         (self._sessions_dir / f"{user_id}.txt").write_text(session_id)
 
-    async def generate_response(self, user_id: str, user_text: str, checkin_prompt: str | None = None) -> str:
+    async def generate_response(
+        self,
+        user_id: str,
+        user_text: str,
+        checkin_prompt: str | None = None,
+        profile: UserProfile | None = None,
+    ) -> str:
         """Generate a response maintaining conversation context via session_id."""
         if checkin_prompt:
             prompt = f"（あなたは先ほどこのメッセージを送りました: 「{checkin_prompt}」）\nユーザーの返信: {user_text}"
         else:
             prompt = user_text
+        system_prompt = SYSTEM_PROMPT
+        if profile is not None:
+            parts = []
+            if profile.interests:
+                parts.append(f"興味・関心: {', '.join(profile.interests)}")
+            if profile.communication_style:
+                parts.append(f"コミュニケーションスタイル: {profile.communication_style}")
+            if profile.recurring_themes:
+                parts.append(f"繰り返し出てくるテーマ: {', '.join(profile.recurring_themes)}")
+            if parts:
+                system_prompt = SYSTEM_PROMPT + "\n\n【このユーザーについて】\n" + "\n".join(parts)
         session_id = self._load_session_id(user_id)
         options = ClaudeAgentOptions(
-            system_prompt=SYSTEM_PROMPT,
+            system_prompt=system_prompt,
             resume=session_id,
             max_turns=1,
             allowed_tools=[],

--- a/src/ai_journaling_agent/core/mood.py
+++ b/src/ai_journaling_agent/core/mood.py
@@ -1,0 +1,50 @@
+"""Mood trend analysis and formatting."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from ai_journaling_agent.core.repository import JournalRepository
+
+
+def get_mood_trend(
+    repository: JournalRepository,
+    user_id: str,
+    days: int = 7,
+    reference_date: date | None = None,
+) -> list[tuple[date, int | None, str | None]]:
+    """Return (date, mood_score, mood_emoji) for each of the last `days` days."""
+    end = reference_date or date.today()
+    result = []
+    for i in range(days - 1, -1, -1):
+        d = end - timedelta(days=i)
+        entries = repository.list_entries(user_id, date=d)
+        mood_score: int | None = None
+        mood_emoji: str | None = None
+        for entry in reversed(entries):
+            if entry.mood is not None:
+                mood_score = entry.mood
+                mood_emoji = entry.mood_emoji
+                break
+        result.append((d, mood_score, mood_emoji))
+    return result
+
+
+_DAY_NAMES = ["月", "火", "水", "木", "金", "土", "日"]
+_SCORE_EMOJI = {1: "😔", 2: "😞", 3: "😐", 4: "😊", 5: "😄"}
+
+
+def format_mood_timeline(trend: list[tuple[date, int | None, str | None]]) -> str:
+    """Format mood trend as a text timeline."""
+    lines = []
+    for d, score, emoji in trend:
+        day_name = _DAY_NAMES[d.weekday()]
+        date_str = f"{d.month}/{d.day}"
+        if emoji:
+            mood_display = emoji
+        elif score is not None:
+            mood_display = _SCORE_EMOJI.get(score, str(score))
+        else:
+            mood_display = "ー"
+        lines.append(f"{day_name}({date_str}): {mood_display}")
+    return "\n".join(lines)

--- a/src/ai_journaling_agent/core/user_profile.py
+++ b/src/ai_journaling_agent/core/user_profile.py
@@ -1,0 +1,68 @@
+"""UserProfile data model and repository."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Protocol
+
+
+@dataclass
+class UserProfile:
+    user_id: str
+    interests: list[str] = field(default_factory=list)
+    communication_style: str = ""
+    recurring_themes: list[str] = field(default_factory=list)
+    updated_at: datetime | None = None
+    profile_update_counter: int = 0
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "user_id": self.user_id,
+            "interests": self.interests,
+            "communication_style": self.communication_style,
+            "recurring_themes": self.recurring_themes,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+            "profile_update_counter": self.profile_update_counter,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> UserProfile:
+        updated_at_raw = data.get("updated_at")
+        return cls(
+            user_id=data["user_id"],
+            interests=list(data.get("interests") or []),
+            communication_style=data.get("communication_style") or "",
+            recurring_themes=list(data.get("recurring_themes") or []),
+            updated_at=datetime.fromisoformat(updated_at_raw) if updated_at_raw else None,
+            profile_update_counter=int(data.get("profile_update_counter") or 0),
+        )
+
+
+class UserProfileRepository(Protocol):
+    def get(self, user_id: str) -> UserProfile | None: ...
+    def save(self, profile: UserProfile) -> None: ...
+
+
+class JsonUserProfileRepository:
+    """JSON-based profile repository. One file per user: {storage_dir}/profiles/{user_id}.json"""
+
+    def __init__(self, storage_dir: Path) -> None:
+        self._storage_dir = storage_dir / "profiles"
+
+    def _profile_file(self, user_id: str) -> Path:
+        return self._storage_dir / f"{user_id}.json"
+
+    def get(self, user_id: str) -> UserProfile | None:
+        path = self._profile_file(user_id)
+        if not path.exists():
+            return None
+        with path.open(encoding="utf-8") as f:
+            return UserProfile.from_dict(json.loads(f.read()))
+
+    def save(self, profile: UserProfile) -> None:
+        self._storage_dir.mkdir(parents=True, exist_ok=True)
+        with self._profile_file(profile.user_id).open("w", encoding="utf-8") as f:
+            f.write(json.dumps(profile.to_dict(), ensure_ascii=False))

--- a/tests/test_mood.py
+++ b/tests/test_mood.py
@@ -1,0 +1,143 @@
+"""Tests for mood trend analysis and formatting."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+from ai_journaling_agent.core.journal import EntryLevel, JournalEntry
+from ai_journaling_agent.core.mood import format_mood_timeline, get_mood_trend
+
+
+def _make_entry(d: date, mood: int | None = None, mood_emoji: str | None = None) -> JournalEntry:
+    return JournalEntry(
+        timestamp=datetime(d.year, d.month, d.day, 12, 0, 0, tzinfo=UTC),
+        level=EntryLevel.EMOJI if mood_emoji else EntryLevel.SUMMARY,
+        summary="テスト",
+        mood=mood,
+        mood_emoji=mood_emoji,
+    )
+
+
+class _StubRepository:
+    """Stub repository that returns pre-configured entries by date."""
+
+    def __init__(self, entries_by_date: dict[date, list[JournalEntry]]) -> None:
+        self._entries = entries_by_date
+
+    def save(self, user_id: str, entry: JournalEntry) -> None:
+        pass
+
+    def list_entries(self, user_id: str, *, date: date | None = None) -> list[JournalEntry]:
+        if date is None:
+            all_entries = []
+            for entries in self._entries.values():
+                all_entries.extend(entries)
+            return all_entries
+        return self._entries.get(date, [])
+
+    def get_latest(self, user_id: str) -> JournalEntry | None:
+        return None
+
+
+class TestGetMoodTrend:
+    """get_mood_trend() returns correct mood data for each day."""
+
+    def test_returns_mood_score_for_days_with_entries(self) -> None:
+        ref = date(2026, 3, 15)
+        d = date(2026, 3, 13)
+        entry = _make_entry(d, mood=4)
+        repo = _StubRepository({d: [entry]})
+
+        trend = get_mood_trend(repo, "U1234", days=7, reference_date=ref)
+
+        assert len(trend) == 7
+        # Find the tuple for 2026-03-13
+        result = {item[0]: item for item in trend}
+        assert result[d][1] == 4
+
+    def test_returns_none_for_days_without_entries(self) -> None:
+        ref = date(2026, 3, 15)
+        repo = _StubRepository({})
+
+        trend = get_mood_trend(repo, "U1234", days=7, reference_date=ref)
+
+        assert len(trend) == 7
+        for d, score, emoji in trend:
+            assert score is None
+            assert emoji is None
+
+    def test_reference_date_param_determines_end_date(self) -> None:
+        ref = date(2026, 1, 10)
+        repo = _StubRepository({})
+
+        trend = get_mood_trend(repo, "U1234", days=3, reference_date=ref)
+
+        dates = [item[0] for item in trend]
+        assert dates == [date(2026, 1, 8), date(2026, 1, 9), date(2026, 1, 10)]
+
+    def test_uses_last_entry_mood_when_multiple_entries(self) -> None:
+        ref = date(2026, 3, 15)
+        d = date(2026, 3, 15)
+        entries = [
+            _make_entry(d, mood=2),
+            _make_entry(d, mood=5),
+        ]
+        repo = _StubRepository({d: entries})
+
+        trend = get_mood_trend(repo, "U1234", days=1, reference_date=ref)
+
+        # Should use last entry with mood (reversed iteration picks last)
+        assert trend[0][1] == 5
+
+    def test_mood_emoji_returned_when_present(self) -> None:
+        ref = date(2026, 3, 15)
+        d = date(2026, 3, 15)
+        entry = _make_entry(d, mood=4, mood_emoji="😊")
+        repo = _StubRepository({d: [entry]})
+
+        trend = get_mood_trend(repo, "U1234", days=1, reference_date=ref)
+
+        assert trend[0][2] == "😊"
+
+
+class TestFormatMoodTimeline:
+    """format_mood_timeline() formats trend as a text timeline."""
+
+    def test_formats_emoji_mood(self) -> None:
+        trend = [(date(2026, 3, 15), 4, "😊")]  # Sunday
+        result = format_mood_timeline(trend)
+        assert "😊" in result
+        assert "3/15" in result
+
+    def test_formats_score_mood_without_emoji(self) -> None:
+        trend = [(date(2026, 3, 15), 3, None)]  # Sunday
+        result = format_mood_timeline(trend)
+        assert "😐" in result
+
+    def test_formats_none_mood_as_dash(self) -> None:
+        trend = [(date(2026, 3, 15), None, None)]
+        result = format_mood_timeline(trend)
+        assert "ー" in result
+
+    def test_formats_multiple_days(self) -> None:
+        trend = [
+            (date(2026, 3, 13), 5, "😄"),   # Friday
+            (date(2026, 3, 14), None, None),  # Saturday
+            (date(2026, 3, 15), 2, None),     # Sunday
+        ]
+        result = format_mood_timeline(trend)
+        lines = result.strip().split("\n")
+        assert len(lines) == 3
+        assert "😄" in lines[0]
+        assert "ー" in lines[1]
+        assert "😞" in lines[2]
+
+    def test_empty_trend_returns_empty_string(self) -> None:
+        result = format_mood_timeline([])
+        assert result == ""
+
+    def test_day_names_in_japanese(self) -> None:
+        # 2026-03-16 is Monday
+        trend = [(date(2026, 3, 16), None, None)]
+        result = format_mood_timeline(trend)
+        assert "月(" in result

--- a/tests/test_user_profile.py
+++ b/tests/test_user_profile.py
@@ -1,0 +1,222 @@
+"""Tests for UserProfile data model and repository."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+from ai_journaling_agent.core.user_profile import JsonUserProfileRepository, UserProfile
+
+
+class TestUserProfileDataclass:
+    """UserProfile serialization round-trips correctly."""
+
+    def test_to_dict_and_from_dict_with_updated_at(self) -> None:
+        now = datetime(2026, 3, 15, 9, 0, 0, tzinfo=UTC)
+        profile = UserProfile(
+            user_id="U1234",
+            interests=["読書", "料理"],
+            communication_style="丁寧",
+            recurring_themes=["健康", "仕事"],
+            updated_at=now,
+            profile_update_counter=3,
+        )
+        data = profile.to_dict()
+        restored = UserProfile.from_dict(data)
+
+        assert restored.user_id == "U1234"
+        assert restored.interests == ["読書", "料理"]
+        assert restored.communication_style == "丁寧"
+        assert restored.recurring_themes == ["健康", "仕事"]
+        assert restored.updated_at == now
+        assert restored.profile_update_counter == 3
+
+    def test_to_dict_and_from_dict_without_updated_at(self) -> None:
+        profile = UserProfile(
+            user_id="U5678",
+            interests=[],
+            communication_style="",
+            recurring_themes=[],
+            updated_at=None,
+            profile_update_counter=0,
+        )
+        data = profile.to_dict()
+        restored = UserProfile.from_dict(data)
+
+        assert restored.user_id == "U5678"
+        assert restored.updated_at is None
+        assert restored.profile_update_counter == 0
+
+    def test_from_dict_tolerates_missing_optional_fields(self) -> None:
+        data = {"user_id": "U9999"}
+        profile = UserProfile.from_dict(data)
+        assert profile.user_id == "U9999"
+        assert profile.interests == []
+        assert profile.communication_style == ""
+        assert profile.recurring_themes == []
+        assert profile.updated_at is None
+        assert profile.profile_update_counter == 0
+
+
+class TestJsonUserProfileRepository:
+    """JsonUserProfileRepository persists user profiles to disk."""
+
+    def test_get_returns_none_for_missing_user(self, tmp_path: Path) -> None:
+        repo = JsonUserProfileRepository(tmp_path)
+        assert repo.get("U_MISSING") is None
+
+    def test_save_and_get_roundtrip(self, tmp_path: Path) -> None:
+        repo = JsonUserProfileRepository(tmp_path)
+        now = datetime(2026, 3, 15, 9, 0, 0, tzinfo=UTC)
+        profile = UserProfile(
+            user_id="U1234",
+            interests=["音楽"],
+            communication_style="カジュアル",
+            recurring_themes=["趣味"],
+            updated_at=now,
+            profile_update_counter=2,
+        )
+        repo.save(profile)
+
+        loaded = repo.get("U1234")
+        assert loaded is not None
+        assert loaded.user_id == "U1234"
+        assert loaded.interests == ["音楽"]
+        assert loaded.communication_style == "カジュアル"
+        assert loaded.recurring_themes == ["趣味"]
+        assert loaded.updated_at == now
+        assert loaded.profile_update_counter == 2
+
+    def test_save_creates_parent_directory(self, tmp_path: Path) -> None:
+        repo = JsonUserProfileRepository(tmp_path / "new_storage")
+        profile = UserProfile(user_id="U_NEW")
+        repo.save(profile)
+        assert repo.get("U_NEW") is not None
+
+    def test_save_overwrites_existing(self, tmp_path: Path) -> None:
+        repo = JsonUserProfileRepository(tmp_path)
+        profile = UserProfile(user_id="U1234", interests=["読書"])
+        repo.save(profile)
+
+        profile.interests = ["映画", "音楽"]
+        repo.save(profile)
+
+        loaded = repo.get("U1234")
+        assert loaded is not None
+        assert loaded.interests == ["映画", "音楽"]
+
+
+class _TextBlock:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _AssistantMessage:
+    def __init__(self, text: str) -> None:
+        self.content = [_TextBlock(text)]
+
+
+class _ResultMessage:
+    def __init__(self, session_id: str) -> None:
+        self.session_id = session_id
+
+
+def _make_query(assistant_text: str, session_id: str = "sid-001"):  # type: ignore[return]
+    async def _mock_query(**kwargs):  # type: ignore[return]
+        yield _AssistantMessage(assistant_text)
+        yield _ResultMessage(session_id)
+
+    return _mock_query
+
+
+def _patch_sdk(assistant_text: str = "返答", session_id: str = "sid-001"):
+    return (
+        patch("ai_journaling_agent.core.ai_responder.query", _make_query(assistant_text, session_id)),
+        patch("ai_journaling_agent.core.ai_responder.AssistantMessage", _AssistantMessage),
+        patch("ai_journaling_agent.core.ai_responder.ResultMessage", _ResultMessage),
+        patch("ai_journaling_agent.core.ai_responder.TextBlock", _TextBlock),
+    )
+
+
+class TestAiResponderWithProfile:
+    """AiResponder uses profile context in system prompt when profile is provided."""
+
+    async def test_profile_context_added_to_system_prompt(self, tmp_path: Path) -> None:
+        from ai_journaling_agent.core.ai_responder import AiResponder
+
+        captured_options: list = []
+
+        async def mock_query(prompt: str, options):  # type: ignore[return]
+            captured_options.append(options)
+            yield _AssistantMessage("返答")
+            yield _ResultMessage("sid-001")
+
+        q_patch, am_patch, rm_patch, tb_patch = (
+            patch("ai_journaling_agent.core.ai_responder.query", mock_query),
+            patch("ai_journaling_agent.core.ai_responder.AssistantMessage", _AssistantMessage),
+            patch("ai_journaling_agent.core.ai_responder.ResultMessage", _ResultMessage),
+            patch("ai_journaling_agent.core.ai_responder.TextBlock", _TextBlock),
+        )
+        with q_patch, am_patch, rm_patch, tb_patch:
+            responder = AiResponder(storage_dir=tmp_path / "data")
+            profile = UserProfile(
+                user_id="U1234",
+                interests=["読書", "料理"],
+                communication_style="丁寧",
+                recurring_themes=["健康"],
+            )
+            await responder.generate_response("U1234", "こんにちは", profile=profile)
+
+        system_prompt = captured_options[0].system_prompt
+        assert "【このユーザーについて】" in system_prompt
+        assert "読書" in system_prompt
+        assert "料理" in system_prompt
+        assert "丁寧" in system_prompt
+        assert "健康" in system_prompt
+
+    async def test_no_profile_system_prompt_unchanged(self, tmp_path: Path) -> None:
+        from ai_journaling_agent.core.ai_responder import SYSTEM_PROMPT, AiResponder
+
+        captured_options: list = []
+
+        async def mock_query(prompt: str, options):  # type: ignore[return]
+            captured_options.append(options)
+            yield _AssistantMessage("返答")
+            yield _ResultMessage("sid-001")
+
+        q_patch, am_patch, rm_patch, tb_patch = (
+            patch("ai_journaling_agent.core.ai_responder.query", mock_query),
+            patch("ai_journaling_agent.core.ai_responder.AssistantMessage", _AssistantMessage),
+            patch("ai_journaling_agent.core.ai_responder.ResultMessage", _ResultMessage),
+            patch("ai_journaling_agent.core.ai_responder.TextBlock", _TextBlock),
+        )
+        with q_patch, am_patch, rm_patch, tb_patch:
+            responder = AiResponder(storage_dir=tmp_path / "data")
+            await responder.generate_response("U1234", "こんにちは", profile=None)
+
+        assert captured_options[0].system_prompt == SYSTEM_PROMPT
+
+    async def test_profile_with_empty_fields_no_user_context_appended(self, tmp_path: Path) -> None:
+        from ai_journaling_agent.core.ai_responder import SYSTEM_PROMPT, AiResponder
+
+        captured_options: list = []
+
+        async def mock_query(prompt: str, options):  # type: ignore[return]
+            captured_options.append(options)
+            yield _AssistantMessage("返答")
+            yield _ResultMessage("sid-001")
+
+        q_patch, am_patch, rm_patch, tb_patch = (
+            patch("ai_journaling_agent.core.ai_responder.query", mock_query),
+            patch("ai_journaling_agent.core.ai_responder.AssistantMessage", _AssistantMessage),
+            patch("ai_journaling_agent.core.ai_responder.ResultMessage", _ResultMessage),
+            patch("ai_journaling_agent.core.ai_responder.TextBlock", _TextBlock),
+        )
+        with q_patch, am_patch, rm_patch, tb_patch:
+            responder = AiResponder(storage_dir=tmp_path / "data")
+            # Profile with all empty fields — no context should be appended
+            profile = UserProfile(user_id="U1234")
+            await responder.generate_response("U1234", "こんにちは", profile=profile)
+
+        assert captured_options[0].system_prompt == SYSTEM_PROMPT


### PR DESCRIPTION
## Summary

- **#32 UserProfile データモデル**: `UserProfile` dataclass + `JsonUserProfileRepository`（`{storage_dir}/profiles/{user_id}.json`）を追加。`AiResponder.generate_response()` に `profile` 引数を追加し、プロフィールがある場合はシステムプロンプトに【このユーザーについて】セクションを付加
- **#35 ムードトレンド可視化**: `get_mood_trend()` / `format_mood_timeline()` を追加。`mood-report` CLI コマンドを追加。LINE ハンドラーにキーワード検出（気分の波/ムード/きぶんのなみ）を追加し、即時返信

## Changes

- `core/user_profile.py` — UserProfile dataclass + JsonUserProfileRepository (新規)
- `core/ai_responder.py` — `profile` オプション引数を追加
- `core/mood.py` — ムードトレンド計算・フォーマット関数 (新規)
- `cli/mood_report_cmd.py` — `mood-report` CLI (新規)
- `adapters/line/bot.py` — profile_repository の初期化・配線
- `adapters/line/handlers.py` — ムード/ふりかえりキーワード検出
- `pyproject.toml` — `mood-report`, `retrospective` エントリポイント追加
- `tests/test_user_profile.py`, `tests/test_mood.py` — テスト (新規)

## Test plan

- [ ] `uv run pytest tests/test_user_profile.py tests/test_mood.py` — 21テスト通過確認
- [ ] `uv run ruff check src/ tests/` — lint クリーン確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)