### PR TITLE
feat: add profile auto-update and retrospective summary (#33, #34)

### DIFF
--- a/src/ai_journaling_agent/cli/retrospective_cmd.py
+++ b/src/ai_journaling_agent/cli/retrospective_cmd.py
@@ -1,0 +1,48 @@
+"""CLI for generating retrospective summaries."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from datetime import UTC, date, datetime, timedelta
+
+from ai_journaling_agent.core.ai_responder import AiResponder
+from ai_journaling_agent.core.config import Settings
+from ai_journaling_agent.core.repository import JsonJournalRepository
+from ai_journaling_agent.core.retrospective import generate_monthly_summary, generate_weekly_summary
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Generate retrospective summary")
+    parser.add_argument("--user", help="LINE user ID (defaults to OWNER_USER_ID)")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--weekly", action="store_true", help="Generate weekly summary (last 7 days)")
+    group.add_argument("--monthly", action="store_true", help="Generate monthly summary (last 30 days)")
+
+    args = parser.parse_args(argv)
+    settings = Settings()  # type: ignore[call-arg]
+
+    user_id = args.user or settings.owner_user_id
+    if not user_id:
+        print("Error: --user required or set OWNER_USER_ID in .env", file=sys.stderr)
+        sys.exit(1)
+
+    repo = JsonJournalRepository(settings.storage_dir)
+    responder = AiResponder(storage_dir=settings.storage_dir)
+    today = datetime.now(tz=UTC).date()
+
+    if args.monthly:
+        month_start = date(today.year, today.month, 1) - timedelta(days=1)
+        month_start = date(month_start.year, month_start.month, 1)
+        summary = asyncio.run(generate_monthly_summary(user_id, month_start, repo, responder))
+    else:
+        # Default: weekly
+        week_start = today - timedelta(days=6)
+        summary = asyncio.run(generate_weekly_summary(user_id, week_start, repo, responder))
+
+    print(summary)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/src/ai_journaling_agent/core/profile_extractor.py
+++ b/src/ai_journaling_agent/core/profile_extractor.py
@@ -1,0 +1,60 @@
+"""Extract profile updates from journal entries using AI."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import UTC, datetime
+
+from ai_journaling_agent.core.user_profile import UserProfile
+
+_EXTRACT_PROMPT = """以下のユーザーメッセージを読んで、このユーザーの特徴を抽出してください。
+
+メッセージ: {user_text}
+
+以下のJSON形式で返してください（情報がなければ空リスト/空文字列にしてください）:
+{{
+  "interests": ["興味・関心のキーワード（最大3つ）"],
+  "recurring_themes": ["繰り返し出てくるテーマ（最大3つ）"],
+  "communication_style": "コミュニケーションスタイルの特徴（一言で、なければ空文字）"
+}}
+
+JSONのみ返してください。説明不要。"""
+
+
+async def extract_profile_updates(
+    user_text: str,
+    existing_profile: UserProfile,
+    ai_responder: AiResponder,  # noqa: F821
+) -> UserProfile:
+    """Extract profile info from user_text and merge into existing_profile."""
+    from ai_journaling_agent.core.ai_responder import AiResponder  # noqa: F401 (type hint)
+
+    prompt = _EXTRACT_PROMPT.format(user_text=user_text)
+    raw = await ai_responder.generate_response(
+        existing_profile.user_id, prompt
+    )
+
+    try:
+        # Extract JSON from response
+        match = re.search(r"\{.*\}", raw, re.DOTALL)
+        if match:
+            data = json.loads(match.group())
+        else:
+            return existing_profile
+    except (json.JSONDecodeError, ValueError):
+        return existing_profile
+
+    new_interests = [i for i in data.get("interests", []) if i and i not in existing_profile.interests]
+    new_themes = [t for t in data.get("recurring_themes", []) if t and t not in existing_profile.recurring_themes]
+    style = data.get("communication_style", "")
+
+    updated = UserProfile(
+        user_id=existing_profile.user_id,
+        interests=existing_profile.interests + new_interests,
+        communication_style=style or existing_profile.communication_style,
+        recurring_themes=existing_profile.recurring_themes + new_themes,
+        updated_at=datetime.now(tz=UTC),
+        profile_update_counter=existing_profile.profile_update_counter,
+    )
+    return updated

--- a/src/ai_journaling_agent/core/retrospective.py
+++ b/src/ai_journaling_agent/core/retrospective.py
@@ -1,0 +1,77 @@
+"""Retrospective summary generation."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import TYPE_CHECKING
+
+from ai_journaling_agent.core.repository import JournalRepository
+
+if TYPE_CHECKING:
+    from ai_journaling_agent.core.ai_responder import AiResponder
+    from ai_journaling_agent.core.user_profile import UserProfile
+
+_SUMMARY_PROMPT = """以下は{user_label}のジャーナル記録です。
+
+{entries_text}
+
+これらの記録から、この期間を振り返るサマリーを作成してください。
+- 事実ベースで記述してください（評価・判断は加えない）
+- できたこと、感謝・嬉しかったこと、学びを自然にまとめてください
+- 3〜5文程度で簡潔に
+- 締めくくりに一言ポジティブなメッセージを添えてください"""
+
+
+def _collect_entries_text(repository: JournalRepository, user_id: str, start: date, end: date) -> str:
+    lines = []
+    current = start
+    while current <= end:
+        entries = repository.list_entries(user_id, date=current)
+        for entry in entries:
+            parts = []
+            if entry.summary:
+                parts.append(entry.summary)
+            if entry.achievements:
+                parts.extend(f"できたこと: {a}" for a in entry.achievements)
+            if entry.gratitude:
+                parts.extend(f"感謝: {g}" for g in entry.gratitude)
+            if entry.learnings:
+                parts.extend(f"学び: {item}" for item in entry.learnings)
+            if parts:
+                lines.append(f"[{current}] " + " / ".join(parts))
+        current += timedelta(days=1)
+    return "\n".join(lines) if lines else ""
+
+
+async def generate_weekly_summary(
+    user_id: str,
+    week_start: date,
+    repository: JournalRepository,
+    responder: AiResponder,
+    profile: UserProfile | None = None,
+) -> str:
+    week_end = week_start + timedelta(days=6)
+    entries_text = _collect_entries_text(repository, user_id, week_start, week_end)
+    if not entries_text:
+        return "この週の記録はありませんでした。"
+    prompt = _SUMMARY_PROMPT.format(user_label="先週1週間", entries_text=entries_text)
+    return await responder.generate_response(user_id, prompt, profile=profile)
+
+
+async def generate_monthly_summary(
+    user_id: str,
+    month_start: date,
+    repository: JournalRepository,
+    responder: AiResponder,
+    profile: UserProfile | None = None,
+) -> str:
+    # Last day of the month
+    if month_start.month == 12:
+        month_end = date(month_start.year + 1, 1, 1) - timedelta(days=1)
+    else:
+        month_end = date(month_start.year, month_start.month + 1, 1) - timedelta(days=1)
+    entries_text = _collect_entries_text(repository, user_id, month_start, month_end)
+    if not entries_text:
+        return "この月の記録はありませんでした。"
+    prompt = _SUMMARY_PROMPT.format(user_label="先月1ヶ月", entries_text=entries_text)
+    return await responder.generate_response(user_id, prompt, profile=profile)

--- a/tests/test_profile_extractor.py
+++ b/tests/test_profile_extractor.py
@@ -1,0 +1,113 @@
+"""Tests for profile_extractor."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+from ai_journaling_agent.core.user_profile import UserProfile
+
+
+class TestExtractProfileUpdates:
+    """extract_profile_updates() merges AI-extracted info into existing profile."""
+
+    async def test_extracts_interests_and_merges(self, tmp_path: Path) -> None:
+        from ai_journaling_agent.core.ai_responder import AiResponder
+        from ai_journaling_agent.core.profile_extractor import extract_profile_updates
+
+        existing = UserProfile(
+            user_id="U1234",
+            interests=["読書"],
+            communication_style="",
+            recurring_themes=[],
+        )
+
+        mock_responder = AsyncMock(spec=AiResponder)
+        mock_responder.generate_response.return_value = (
+            '{"interests": ["料理", "読書"], "recurring_themes": ["健康"], "communication_style": "丁寧"}'
+        )
+
+        result = await extract_profile_updates("料理が好きです", existing, mock_responder)
+
+        # "読書" is already in existing, should not be duplicated
+        assert "読書" in result.interests
+        assert "料理" in result.interests
+        assert result.interests.count("読書") == 1
+        assert "健康" in result.recurring_themes
+        assert result.communication_style == "丁寧"
+
+    async def test_handles_invalid_json_gracefully(self, tmp_path: Path) -> None:
+        from ai_journaling_agent.core.ai_responder import AiResponder
+        from ai_journaling_agent.core.profile_extractor import extract_profile_updates
+
+        existing = UserProfile(
+            user_id="U1234",
+            interests=["読書"],
+        )
+
+        mock_responder = AsyncMock(spec=AiResponder)
+        mock_responder.generate_response.return_value = "申し訳ありませんが、処理できませんでした。"
+
+        result = await extract_profile_updates("テスト", existing, mock_responder)
+
+        # Should return existing profile unchanged
+        assert result is existing
+
+    async def test_handles_empty_json_fields(self, tmp_path: Path) -> None:
+        from ai_journaling_agent.core.ai_responder import AiResponder
+        from ai_journaling_agent.core.profile_extractor import extract_profile_updates
+
+        existing = UserProfile(
+            user_id="U1234",
+            interests=["読書"],
+            communication_style="カジュアル",
+            recurring_themes=["仕事"],
+        )
+
+        mock_responder = AsyncMock(spec=AiResponder)
+        mock_responder.generate_response.return_value = (
+            '{"interests": [], "recurring_themes": [], "communication_style": ""}'
+        )
+
+        result = await extract_profile_updates("テスト", existing, mock_responder)
+
+        # Empty fields should not overwrite existing data
+        assert result.interests == ["読書"]
+        assert result.communication_style == "カジュアル"
+        assert result.recurring_themes == ["仕事"]
+
+    async def test_does_not_duplicate_existing_themes(self, tmp_path: Path) -> None:
+        from ai_journaling_agent.core.ai_responder import AiResponder
+        from ai_journaling_agent.core.profile_extractor import extract_profile_updates
+
+        existing = UserProfile(
+            user_id="U1234",
+            interests=["音楽"],
+            recurring_themes=["健康", "仕事"],
+        )
+
+        mock_responder = AsyncMock(spec=AiResponder)
+        mock_responder.generate_response.return_value = (
+            '{"interests": ["音楽", "スポーツ"], "recurring_themes": ["健康"], "communication_style": ""}'
+        )
+
+        result = await extract_profile_updates("テスト", existing, mock_responder)
+
+        assert result.interests.count("音楽") == 1
+        assert "スポーツ" in result.interests
+        assert result.recurring_themes.count("健康") == 1
+
+    async def test_updated_at_is_set(self, tmp_path: Path) -> None:
+        from ai_journaling_agent.core.ai_responder import AiResponder
+        from ai_journaling_agent.core.profile_extractor import extract_profile_updates
+
+        existing = UserProfile(user_id="U1234", updated_at=None)
+
+        mock_responder = AsyncMock(spec=AiResponder)
+        mock_responder.generate_response.return_value = (
+            '{"interests": ["映画"], "recurring_themes": [], "communication_style": ""}'
+        )
+
+        result = await extract_profile_updates("映画が好き", existing, mock_responder)
+
+        assert result.updated_at is not None

--- a/tests/test_retrospective.py
+++ b/tests/test_retrospective.py
@@ -1,0 +1,135 @@
+"""Tests for retrospective summary generation."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from unittest.mock import AsyncMock
+
+from ai_journaling_agent.core.journal import EntryLevel, JournalEntry
+
+
+def _make_entry(d: date, summary: str = "今日も頑張った") -> JournalEntry:
+    return JournalEntry(
+        timestamp=datetime(d.year, d.month, d.day, 12, 0, 0, tzinfo=UTC),
+        level=EntryLevel.SUMMARY,
+        summary=summary,
+    )
+
+
+class _StubRepository:
+    """Stub repository that returns pre-configured entries by date."""
+
+    def __init__(self, entries_by_date: dict[date, list[JournalEntry]]) -> None:
+        self._entries = entries_by_date
+
+    def save(self, user_id: str, entry: JournalEntry) -> None:
+        pass
+
+    def list_entries(self, user_id: str, *, date: date | None = None) -> list[JournalEntry]:
+        if date is None:
+            all_entries = []
+            for entries in self._entries.values():
+                all_entries.extend(entries)
+            return all_entries
+        return self._entries.get(date, [])
+
+    def get_latest(self, user_id: str) -> JournalEntry | None:
+        return None
+
+
+class TestGenerateWeeklySummary:
+    """generate_weekly_summary() generates or skips based on entries."""
+
+    async def test_no_entries_returns_no_record_message(self) -> None:
+        from ai_journaling_agent.core.ai_responder import AiResponder
+        from ai_journaling_agent.core.retrospective import generate_weekly_summary
+
+        repo = _StubRepository({})
+        mock_responder = AsyncMock(spec=AiResponder)
+
+        result = await generate_weekly_summary("U1234", date(2026, 3, 10), repo, mock_responder)
+
+        assert result == "この週の記録はありませんでした。"
+        mock_responder.generate_response.assert_not_called()
+
+    async def test_with_entries_calls_ai_responder(self) -> None:
+        from ai_journaling_agent.core.ai_responder import AiResponder
+        from ai_journaling_agent.core.retrospective import generate_weekly_summary
+
+        week_start = date(2026, 3, 10)
+        entry_date = date(2026, 3, 12)
+        repo = _StubRepository({entry_date: [_make_entry(entry_date, "プロジェクト完了")]})
+
+        mock_responder = AsyncMock(spec=AiResponder)
+        mock_responder.generate_response.return_value = "今週は素晴らしい1週間でした。"
+
+        result = await generate_weekly_summary("U1234", week_start, repo, mock_responder)
+
+        assert result == "今週は素晴らしい1週間でした。"
+        mock_responder.generate_response.assert_called_once()
+        call_args = mock_responder.generate_response.call_args
+        # The prompt should contain the entry text
+        prompt_arg = call_args[0][1]  # second positional arg is user_text/prompt
+        assert "プロジェクト完了" in prompt_arg
+
+    async def test_with_entries_and_achievements(self) -> None:
+        from ai_journaling_agent.core.ai_responder import AiResponder
+        from ai_journaling_agent.core.retrospective import generate_weekly_summary
+
+        week_start = date(2026, 3, 10)
+        entry_date = date(2026, 3, 11)
+        entry = JournalEntry(
+            timestamp=datetime(2026, 3, 11, 12, 0, 0, tzinfo=UTC),
+            level=EntryLevel.STRUCTURED,
+            summary="今日の記録",
+            achievements=["タスク完了"],
+            gratitude=["チームに感謝"],
+            learnings=["新しい手法を学んだ"],
+        )
+        repo = _StubRepository({entry_date: [entry]})
+
+        mock_responder = AsyncMock(spec=AiResponder)
+        mock_responder.generate_response.return_value = "振り返りサマリー"
+
+        result = await generate_weekly_summary("U1234", week_start, repo, mock_responder)
+
+        assert result == "振り返りサマリー"
+        call_args = mock_responder.generate_response.call_args
+        prompt_arg = call_args[0][1]
+        assert "タスク完了" in prompt_arg
+        assert "チームに感謝" in prompt_arg
+        assert "新しい手法を学んだ" in prompt_arg
+
+
+class TestGenerateMonthlySummary:
+    """generate_monthly_summary() generates or skips based on entries."""
+
+    async def test_no_entries_returns_no_record_message(self) -> None:
+        from ai_journaling_agent.core.ai_responder import AiResponder
+        from ai_journaling_agent.core.retrospective import generate_monthly_summary
+
+        repo = _StubRepository({})
+        mock_responder = AsyncMock(spec=AiResponder)
+
+        result = await generate_monthly_summary("U1234", date(2026, 2, 1), repo, mock_responder)
+
+        assert result == "この月の記録はありませんでした。"
+        mock_responder.generate_response.assert_not_called()
+
+    async def test_december_month_end_calculated_correctly(self) -> None:
+        from ai_journaling_agent.core.ai_responder import AiResponder
+        from ai_journaling_agent.core.retrospective import generate_monthly_summary
+
+        # December: month_end should be Dec 31
+        entry_date = date(2026, 12, 25)
+        repo = _StubRepository({entry_date: [_make_entry(entry_date, "クリスマス")]})
+
+        mock_responder = AsyncMock(spec=AiResponder)
+        mock_responder.generate_response.return_value = "12月のふりかえり"
+
+        result = await generate_monthly_summary("U1234", date(2026, 12, 1), repo, mock_responder)
+
+        assert result == "12月のふりかえり"
+        call_args = mock_responder.generate_response.call_args
+        prompt_arg = call_args[0][1]
+        assert "クリスマス" in prompt_arg


### PR DESCRIPTION
## Summary

- **#33 プロファイル自動更新**: `extract_profile_updates()` で会話からユーザー情報を AI 抽出してプロフィールにマージ。5メッセージごとにバックグラウンド実行
- **#34 ふりかえりサマリー**: `generate_weekly_summary()` / `generate_monthly_summary()` を追加。`retrospective` CLI コマンドを追加。LINE ハンドラーにキーワード検出（今週のふりかえり/ふりかえり/振り返り）を追加

> #66 マージ後の再作成 PR（旧 #67）

## Changes

- `core/profile_extractor.py` — AI による interests/themes/style 抽出・マージ (新規)
- `core/retrospective.py` — 週次・月次サマリー生成 (新規)
- `cli/retrospective_cmd.py` — `retrospective` CLI (新規)
- `tests/test_profile_extractor.py`, `tests/test_retrospective.py` — テスト (新規)

## Test plan

- [ ] `uv run pytest tests/test_profile_extractor.py tests/test_retrospective.py` — 10テスト通過確認
- [ ] `uv run pytest` — 全157テスト通過確認
- [ ] `uv run ruff check src/ tests/` — lint クリーン確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)