### PR TITLE
refactor: 時刻注入 — datetime.now() をオプション引数化 (#69)

### DIFF
--- a/src/ai_journaling_agent/cli/checkin_cmd.py
+++ b/src/ai_journaling_agent/cli/checkin_cmd.py
@@ -18,16 +18,19 @@ def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Check-in management")
     sub = parser.add_subparsers(dest="command", required=True)
 
-    sub.add_parser("status", help="Check if a check-in is needed now")
+    status_p = sub.add_parser("status", help="Check if a check-in is needed now")
+    status_p.add_argument("--now", default=None, help="Override current time (ISO 8601, e.g. 2026-01-06T09:00:00)")
 
     record = sub.add_parser("record", help="Record that a check-in was sent")
     record.add_argument("--kind", required=True, choices=["morning", "midday", "evening", "night_summary"])
     record.add_argument("--text", default=None, help="The prompt text that was sent (optional)")
+    record.add_argument("--now", default=None, help="Override current time (ISO 8601, e.g. 2026-01-06T09:00:00)")
 
     args = parser.parse_args(argv)
     settings = Settings()  # type: ignore[call-arg]
     tracker = CheckInTracker(settings.storage_dir)
-    now = datetime.now(tz=UTC)
+    _now = datetime.fromisoformat(args.now).replace(tzinfo=UTC) if args.now else datetime.now(tz=UTC)
+    now = _now
 
     if args.command == "status":
         prompt = tracker.needs_checkin(now)

--- a/src/ai_journaling_agent/cli/history_cmd.py
+++ b/src/ai_journaling_agent/cli/history_cmd.py
@@ -16,6 +16,7 @@ def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="View recent journal entries")
     parser.add_argument("--user", help="LINE user ID (defaults to OWNER_USER_ID)")
     parser.add_argument("--days", type=int, default=3, help="Number of days to show (default: 3)")
+    parser.add_argument("--now", default=None, help="Override current time (ISO 8601, e.g. 2026-01-06T09:00:00)")
 
     args = parser.parse_args(argv)
     settings = Settings()  # type: ignore[call-arg]
@@ -26,7 +27,8 @@ def main(argv: list[str] | None = None) -> None:
         sys.exit(1)
 
     repo = JsonJournalRepository(settings.storage_dir)
-    cutoff = datetime.now(tz=UTC) - timedelta(days=args.days)
+    _now = datetime.fromisoformat(args.now).replace(tzinfo=UTC) if args.now else datetime.now(tz=UTC)
+    cutoff = _now - timedelta(days=args.days)
 
     entries = repo.list_entries(user_id)
     recent = [e for e in entries if e.timestamp >= cutoff]

--- a/src/ai_journaling_agent/cli/retrospective_cmd.py
+++ b/src/ai_journaling_agent/cli/retrospective_cmd.py
@@ -16,6 +16,7 @@ from ai_journaling_agent.core.retrospective import generate_monthly_summary, gen
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Generate retrospective summary")
     parser.add_argument("--user", help="LINE user ID (defaults to OWNER_USER_ID)")
+    parser.add_argument("--now", default=None, help="Override current time (ISO 8601, e.g. 2026-01-06T09:00:00)")
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--weekly", action="store_true", help="Generate weekly summary (last 7 days)")
     group.add_argument("--monthly", action="store_true", help="Generate monthly summary (last 30 days)")
@@ -30,7 +31,8 @@ def main(argv: list[str] | None = None) -> None:
 
     repo = JsonJournalRepository(settings.storage_dir)
     responder = AiResponder(storage_dir=settings.storage_dir)
-    today = datetime.now(tz=UTC).date()
+    _now = datetime.fromisoformat(args.now).replace(tzinfo=UTC) if args.now else datetime.now(tz=UTC)
+    today = _now.date()
 
     if args.monthly:
         month_start = date(today.year, today.month, 1) - timedelta(days=1)

--- a/src/ai_journaling_agent/cli/today_cmd.py
+++ b/src/ai_journaling_agent/cli/today_cmd.py
@@ -19,6 +19,7 @@ def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="View journal entries by date (JST, defaults to today)")
     parser.add_argument("--user", help="LINE user ID (defaults to OWNER_USER_ID)")
     parser.add_argument("--date", help="Date to view in YYYY-MM-DD format (defaults to today JST)")
+    parser.add_argument("--now", default=None, help="Override current time (ISO 8601, e.g. 2026-01-06T09:00:00)")
 
     args = parser.parse_args(argv)
     settings = Settings()  # type: ignore[call-arg]
@@ -35,7 +36,8 @@ def main(argv: list[str] | None = None) -> None:
             print(f"Error: invalid date format '{args.date}' (expected YYYY-MM-DD)", file=sys.stderr)
             sys.exit(1)
     else:
-        target_date = datetime.now(tz=UTC).astimezone(JST).date()
+        _now = datetime.fromisoformat(args.now).replace(tzinfo=UTC) if args.now else datetime.now(tz=UTC)
+        target_date = _now.astimezone(JST).date()
 
     repo = JsonJournalRepository(settings.storage_dir)
     entries = repo.list_entries(user_id)

--- a/src/ai_journaling_agent/core/checkin.py
+++ b/src/ai_journaling_agent/core/checkin.py
@@ -83,7 +83,7 @@ class CheckInTracker:
         data["last_sent_at"] = sent_at.isoformat()
         self._save(data)
 
-    def get_recent_prompt(self, within_hours: int = 8) -> str | None:
+    def get_recent_prompt(self, within_hours: int = 8, now: datetime | None = None) -> str | None:
         """Return the prompt text if sent within the given number of hours."""
         data = self._load()
         prompt = data.get("last_sent_prompt")
@@ -91,6 +91,7 @@ class CheckInTracker:
         if not prompt or not sent_at_str:
             return None
         sent_at = datetime.fromisoformat(sent_at_str)
-        if (datetime.now(tz=UTC) - sent_at).total_seconds() < within_hours * 3600:
+        _now = now or datetime.now(tz=UTC)
+        if (_now - sent_at).total_seconds() < within_hours * 3600:
             return prompt
         return None


### PR DESCRIPTION
## Summary

`datetime.now()` のハードコードをオプション引数 `now: datetime | None = None` に統一。統合テスト・CLI での時刻固定が可能になる。

## Changes

- `core/checkin.py` — `get_recent_prompt(now=None)` 引数化
- `cli/checkin_cmd.py`, `history_cmd.py`, `today_cmd.py`, `retrospective_cmd.py` — `--now ISO` オプション追加

## Test plan

- [ ] `uv run pytest` 通過
- [ ] `uv run ruff check src/ tests/` クリーン

Closes #69
🤖 Generated with [Claude Code](https://claude.com/claude-code)