### PR TITLE
test: AI-as-tester — レスポンス品質自動評価 (#72)

### DIFF
--- a/src/ai_journaling_agent/core/ai_evaluator.py
+++ b/src/ai_journaling_agent/core/ai_evaluator.py
@@ -1,0 +1,47 @@
+"""AI response quality evaluator — stateless Claude evaluator."""
+
+from __future__ import annotations
+
+from claude_agent_sdk import AssistantMessage, ClaudeAgentOptions, TextBlock, query
+
+EVALUATOR_SYSTEM_PROMPT = """あなたはジャーナリングAIアシスタントの品質評価者です。
+
+ユーザーのメッセージとAIの返答を受け取り、以下の基準で評価してください:
+1. ユーザーへの共感が適切か（押しつけがましくない）
+2. 記録や振り返りへの誘導があるか
+3. 返答が3文以内か
+4. 日本語として自然か
+
+以下のJSON形式のみで返答してください（説明不要）:
+{"pass": true/false, "score": 1-5, "reason": "一言で"}"""
+
+
+class AiEvaluator:
+    """Stateless AI evaluator for journaling agent response quality."""
+
+    async def evaluate(self, user_message: str, ai_response: str) -> dict[str, object]:
+        """Evaluate an AI response. Returns {"pass": bool, "score": int, "reason": str}."""
+        import json
+        import re
+
+        prompt = f"ユーザー: {user_message}\nAI返答: {ai_response}"
+        options = ClaudeAgentOptions(
+            system_prompt=EVALUATOR_SYSTEM_PROMPT,
+            resume=None,  # always stateless
+            max_turns=1,
+            allowed_tools=[],
+        )
+        text = ""
+        async for msg in query(prompt=prompt, options=options):
+            if isinstance(msg, AssistantMessage):
+                for block in msg.content:
+                    if isinstance(block, TextBlock):
+                        text += block.text
+        # parse JSON
+        match = re.search(r"\{.*\}", text, re.DOTALL)
+        if match:
+            try:
+                return json.loads(match.group())  # type: ignore[no-any-return]
+            except json.JSONDecodeError:
+                pass
+        return {"pass": False, "score": 0, "reason": f"parse error: {text}"}

--- a/tests/test_ai_quality.py
+++ b/tests/test_ai_quality.py
@@ -1,0 +1,52 @@
+"""AI response quality tests — requires ANTHROPIC_API_KEY."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.fixture(autouse=True)
+def require_api_key() -> None:
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        pytest.skip("ANTHROPIC_API_KEY not set")
+
+
+class TestAiResponseQuality:
+    async def test_emoji_response_steers_to_journaling(self, tmp_path: Path) -> None:
+        from ai_journaling_agent.core.ai_evaluator import AiEvaluator
+        from ai_journaling_agent.core.ai_responder import AiResponder
+
+        responder = AiResponder(storage_dir=tmp_path / "data")
+        evaluator = AiEvaluator()
+        response = await responder.generate_response("eval-user", "😊")
+        result = await evaluator.evaluate("😊", response)
+        assert result.get("pass") is True, f"評価失敗: {result.get('reason')}"
+
+    async def test_story_response_acknowledges_and_asks(self, tmp_path: Path) -> None:
+        from ai_journaling_agent.core.ai_evaluator import AiEvaluator
+        from ai_journaling_agent.core.ai_responder import AiResponder
+
+        responder = AiResponder(storage_dir=tmp_path / "data")
+        evaluator = AiEvaluator()
+        response = await responder.generate_response("eval-user", "今日は大事な発表があってうまくいった")
+        result = await evaluator.evaluate("今日は大事な発表があってうまくいった", response)
+        assert result.get("pass") is True, f"評価失敗: {result.get('reason')}"
+
+    async def test_response_is_concise(self, tmp_path: Path) -> None:
+        """Response should be 3 sentences or fewer."""
+        from ai_journaling_agent.core.ai_responder import AiResponder
+
+        responder = AiResponder(storage_dir=tmp_path / "data")
+        response = await responder.generate_response("eval-user", "今日は本当に色々あって疲れました")
+        assert isinstance(response, str)
+        assert len(response) > 0
+        # Structural check: count sentence-ending punctuation
+        import re
+        sentences = re.split(r"[。！？\n]", response.strip())
+        non_empty = [s for s in sentences if s.strip()]
+        assert len(non_empty) <= 5, f"返答が長すぎます ({len(non_empty)}文): {response}"


### PR DESCRIPTION
## Summary

評価者 Claude（ステートレス）による AI レスポンス品質テスト（`@pytest.mark.e2e`、`ANTHROPIC_API_KEY` 必要）。

## Changes

- `core/ai_evaluator.py` — 評価者 Claude クライアント
- `tests/test_ai_quality.py` — 3テスト（API キーなしで自動 skip）

> 依存: #71

Closes #72
🤖 Generated with [Claude Code](https://claude.com/claude-code)