### PR TITLE
ci: e2e テスト CI + PR 自動レビュー (#73)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,4 @@ jobs:
         run: uv run ruff check src/ tests/
 
       - name: Test
-        run: uv run pytest
+        run: uv run pytest -m "not e2e"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,24 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: anthropics/claude-code-base-action@beta
+        continue-on-error: true
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            このPRのコードをレビューしてください。以下の観点を重視してください:
+            - core/ のロジックが LINE 非依存のアーキテクチャを維持しているか
+            - テストが適切に書かれているか（datetime.now() のハードコードがないか等）
+            - 新しい依存関係が適切か
+            コメントは日本語でお願いします。

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,19 @@
+name: e2e tests
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - run: uv python install 3.12
+      - run: uv sync --group dev
+      - run: uv run pytest -m e2e -v
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

- `ci.yml` に `-m "not e2e"` 追加（e2e を通常 CI から除外）
- `e2e.yml` — PR → main 時に `pytest -m e2e` を実行
- `claude-review.yml` — `claude-code-base-action` による PR 自動レビュー（`ANTHROPIC_API_KEY` を Secrets に設定で有効化）

> 依存: #72

Closes #73
🤖 Generated with [Claude Code](https://claude.com/claude-code)